### PR TITLE
Fix cross-compilation for 32bit build

### DIFF
--- a/code/qcommon/vm_x86.c
+++ b/code/qcommon/vm_x86.c
@@ -93,7 +93,7 @@ static	int		asmCallPtr = (int)doAsmCall;
 #endif
 
 
-static	int		callMask = 0;
+static	int __attribute__((used))		callMask = 0;
 
 static	int	instruction, pass;
 static	int	lastConst = 0;


### PR DESCRIPTION
gives error "undefined reference to `callMask'" otherwise
fixed from http://lists.freebsd.org/pipermail/freebsd-ports-bugs/2013-October/264198.html
